### PR TITLE
Add explicit `std` conversion functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,26 @@ pub enum Stdio {
     Null,
 }
 
+impl Stdio {
+    /// Convert this value into a [`std::process::Stdio`].
+    #[must_use]
+    pub fn as_std(&self) -> StdStdio {
+        self.into()
+    }
+}
+
 impl From<Stdio> for StdStdio {
     fn from(value: Stdio) -> Self {
+        match value {
+            Stdio::Inherit => StdStdio::inherit(),
+            Stdio::Piped => StdStdio::piped(),
+            Stdio::Null => StdStdio::null(),
+        }
+    }
+}
+
+impl From<&Stdio> for StdStdio {
+    fn from(value: &Stdio) -> Self {
         match value {
             Stdio::Inherit => StdStdio::inherit(),
             Stdio::Piped => StdStdio::piped(),
@@ -270,5 +288,11 @@ impl Command {
     /// Behaves identical to std's [`Command::status`](StdCommand::status).
     pub fn status(&self) -> Result<ExitStatus> {
         StdCommand::from(self).status()
+    }
+
+    /// Convert this command to a [`std::process::Command`].
+    #[must_use]
+    pub fn as_std(&self) -> StdCommand {
+        self.into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ impl Command {
 
     /// Convert this command to a [`std::process::Command`].
     #[must_use]
-    pub fn as_std(&self) -> StdCommand {
+    pub fn to_std(&self) -> StdCommand {
         self.into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub enum Stdio {
 impl Stdio {
     /// Convert this value into a [`std::process::Stdio`].
     #[must_use]
-    pub fn as_std(&self) -> StdStdio {
+    pub fn to_std(&self) -> StdStdio {
         self.into()
     }
 }


### PR DESCRIPTION
Adds [`Stdio::as_std`] and [`Command::as_std`] to convert to the equivalent standard library types.